### PR TITLE
Make random number available on block replay

### DIFF
--- a/blockchain/store.go
+++ b/blockchain/store.go
@@ -69,6 +69,18 @@ func (bs *BlockStore) LoadBlock(height int64) *types.Block {
 		// block. So, make sure meta is only saved after blocks are saved.
 		panic(cmn.ErrorWrap(err, "Error reading block"))
 	}
+
+	// A block is split into parts during propose step, while the random number is generated on commit
+	// and stored in the block header, which is stored separately from block parts.
+	//
+	// The problem is that, the block which is transferred to the application via ABCI's BeginBlock
+	// method won't contain the generated random by the time the block is loaded,
+	// so here the block's random is filled with block's meta random
+	//
+	// holy cow, I'm not sure if it's actually ok to do so
+	block.RandomNumber = blockMeta.Header.RandomNumber
+	block.RandomHash = blockMeta.Header.RandomHash
+
 	return block
 }
 


### PR DESCRIPTION
This PR makes the random number available when replaying blocks. In other words the random number will be available in ABCI BeginBlock's request when Tendermint syncs with the application state.